### PR TITLE
Exclude paths by glob and modified lines calculation

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,8 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Label the PR size
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./
+        name: Run Action
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           thresholds: |
@@ -25,4 +28,7 @@ jobs:
               less_than: 1000
               label: large
             fail_if_xl: true
-            message_if_xl: This PR is sooooo big!! 😳
+            message_if_xl: The PR size is XL
+          exclude_paths: |
+            - go.mod
+            - go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.21-alpine
-RUN apk add git
+FROM golang:1.21
+RUN apt-get update && apt-get install -y git diffstat
 
 COPY . /home/src
 WORKDIR /home/src

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/friendsofgo/pr-size-labeler
 go 1.21
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/google/go-github/v31 v31.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kr/pretty v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Uses `diffstat -m` calculation which only counts changed lines instead of double counting added + removed lines.